### PR TITLE
token_renewer: use new callback signature

### DIFF
--- a/wazo_dird_phoned/controller.py
+++ b/wazo_dird_phoned/controller.py
@@ -46,5 +46,5 @@ class Controller:
             verify_certificate=auth_config['verify_certificate'],
         )
 
-    def _on_token_change(self, token_id):
-        self.http_server.app.config['token'] = token_id
+    def _on_token_change(self, token):
+        self.http_server.app.config['token'] = token['token']


### PR DESCRIPTION
token_renewer now passes the whole token object to callbacks